### PR TITLE
Added contributions and bug reporting sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For features, simply provide a brief description of the feature and any design d
 clarity to the work that needs to be done for the feature to be considered "complete". 
 
 When setting up a Pull Request, remember to reference the issue number in the request so we know
-what to look for in review. Make sure the code is clean and free of extraneous comments or notes.
-We'll get to the Pull Request as soon as we can and give our feedback on the contribution if any
-is warranted. Once the request passes review, the issue will be closed and the contribution should
-now appear in the `main` branch. 
+what to look for during the review. Make sure the code is clean and free of extraneous comments or
+notes. We'll get to the Pull Request as soon as we can and give our feedback on the contribution if
+any is warranted. Once the request passes review, the issue will be closed and the contribution
+should now appear in the `main` branch. 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,28 @@ cargo run "127.0.0.1:8091" "127.0.0.1.8090"
 
 This command will start a node and if connected to another node will allow command line
 communication between the two nodes.
+
+# Bug Reporting
+
+To report a bug or defect, it is helpful to understand a user's development environment and the
+extent of the abnormal behavior they are experiencing. Simply open a new issue and provide a brief
+description of the bug or defect in the title. Then in the description describe your development
+environment, which commit you are building from, which version of Rust that is being used, and
+other relevant information. This information helps to recreate the bug on our end. 
+
+In a separate paragraph describe the unexpected or undesired behavior. The more detailed this
+description is, the more likely we will be able to pinpoint the issue. Logs and screenshots
+demonstrating the bug or defect are helpful as well.
+
+# Contributions
+
+To contribute to the project, either open a new issue for a bug or feature that currently is not
+listed there or find a bug or feature present in the issue list that you would like to address. 
+For features, simply provide a brief description of the feature and any design details that add
+clarity to the work that needs to be done for the feature to be considered "complete". 
+
+When setting up a Pull Request, remember to reference the issue number in the request so we know
+what to look for in review. Make sure the code is clean and free of extraneous comments or notes.
+We'll get to the Pull Request as soon as we can and give our feedback on the contribution if any
+is warranted. Once the request passes review, the issue will be closed and the contribution should
+now appear in the `main` branch. 


### PR DESCRIPTION
Add two sections to the README to facilitate issue reporting and feature development external to the Lotus Locke team. If anything makes sense to add to the descriptions (or my English is subpar), make notes of it and I'll update the PR.