### PR TITLE
Separated Library into Modules

### DIFF
--- a/open-pond-protocol/src/lib.rs
+++ b/open-pond-protocol/src/lib.rs
@@ -1,61 +1,6 @@
-use std::io::{self, Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::thread;
-use std::time;
+//! Library that implements the Open Pond Protocol
+mod peer_pool;
+mod servicer;
 
-pub fn start_servicer(address: String) -> std::io::Result<()> {
-    let server = TcpListener::bind(address)?;
-
-    for stream in server.incoming() {
-        match stream {
-            Ok(stream) => {
-                println!("Accepting peer's connection");
-                thread::spawn(|| serve(stream));
-            }
-            Err(_) => println!("An error occured trying to make connection!"),
-        };
-    }
-
-    Ok(())
-}
-
-pub fn start_peer_pool(address: String) -> std::io::Result<()> {
-    loop {
-        thread::sleep(time::Duration::new(1, 0));
-        if let Ok(stream) = TcpStream::connect(address.clone()) {
-            println!("Peer accepted connection request");
-            thread::spawn(|| request(stream));
-            break;
-        }
-    }
-
-    Ok(())
-}
-
-fn serve(mut stream: TcpStream) -> std::io::Result<()> {
-    loop {
-        thread::sleep(time::Duration::new(1, 0));
-
-        let mut mail = String::new();
-        if io::stdin().read_line(&mut mail).is_ok() {
-            println!("Sending out: {}", mail);
-            stream.write_all(mail.as_bytes())?;
-        } else {
-            break;
-        }
-    }
-    Ok(())
-}
-
-fn request(mut stream: TcpStream) -> std::io::Result<()> {
-    loop {
-        let mut response = [0; 1024];
-        thread::sleep(time::Duration::new(1, 0));
-        if stream.read_exact(&mut response).is_ok() {
-            println!("Response: {}", std::str::from_utf8(&response).unwrap());
-        } else {
-            break;
-        }
-    }
-    Ok(())
-}
+pub use crate::peer_pool::*;
+pub use crate::servicer::*;

--- a/open-pond-protocol/src/peer_pool.rs
+++ b/open-pond-protocol/src/peer_pool.rs
@@ -1,0 +1,31 @@
+use std::io::Read;
+use std::net::TcpStream;
+use std::thread;
+use std::time;
+
+/// Spawns request threads for each peer in the active peer pool
+pub fn start_peer_pool(address: String) -> std::io::Result<()> {
+    loop {
+        thread::sleep(time::Duration::new(1, 0));
+        if let Ok(stream) = TcpStream::connect(address.clone()) {
+            println!("Peer accepted connection request");
+            thread::spawn(|| request(stream));
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn request(mut stream: TcpStream) -> std::io::Result<()> {
+    loop {
+        let mut response = [0; 1024];
+        thread::sleep(time::Duration::new(1, 0));
+        if stream.read_exact(&mut response).is_ok() {
+            println!("Response: {}", std::str::from_utf8(&response).unwrap());
+        } else {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/open-pond-protocol/src/servicer.rs
+++ b/open-pond-protocol/src/servicer.rs
@@ -1,0 +1,36 @@
+use std::io::{self, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time;
+
+/// Starts the servicer handling threads
+pub fn start_servicer(address: String) -> std::io::Result<()> {
+    let server = TcpListener::bind(address)?;
+
+    for stream in server.incoming() {
+        match stream {
+            Ok(stream) => {
+                println!("Accepting peer's connection");
+                thread::spawn(|| serve(stream));
+            }
+            Err(_) => println!("An error occured trying to make connection!"),
+        };
+    }
+
+    Ok(())
+}
+
+fn serve(mut stream: TcpStream) -> std::io::Result<()> {
+    loop {
+        thread::sleep(time::Duration::new(1, 0));
+
+        let mut mail = String::new();
+        if io::stdin().read_line(&mut mail).is_ok() {
+            println!("Sending out: {}", mail);
+            stream.write_all(mail.as_bytes())?;
+        } else {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/open-pond/src/main.rs
+++ b/open-pond/src/main.rs
@@ -1,8 +1,8 @@
+use open_pond_protocol::{start_peer_pool, start_servicer};
 use std::env;
 use std::thread;
 
-use open_pond_protocol::{start_peer_pool, start_servicer};
-
+/// Thread that starts an active Open Pond node
 fn main() -> std::io::Result<()> {
     let server_address = env::args()
         .nth(1)
@@ -12,7 +12,7 @@ fn main() -> std::io::Result<()> {
         .unwrap_or_else(|| "127.0.0.1:8081".to_string());
 
     let servicer_handle = thread::spawn(|| start_servicer(server_address));
-    println!("Server spawned");
+    println!("Open Pond node started");
 
     start_peer_pool(peer_address)?;
 


### PR DESCRIPTION
Peer Pool and Servicer now split into two files. Also added documentation that can be generated and displayed with following command:

```
cargo doc --open
```